### PR TITLE
fixed `DerivedData` function calculation

### DIFF
--- a/FlexTransform/Configuration/Config.py
+++ b/FlexTransform/Configuration/Config.py
@@ -154,11 +154,11 @@ class Config(object):
         if hasattr(source_file, "name") and source_file is not None:
             source_file_name = source_file.name
         else:
-            source_file_name = None
+            source_file_name = ""
         if hasattr(dest_file, "name") and dest_file is not None:
             dest_file_name = dest_file.name
         else:
-            dest_file_name = None
+            dest_file_name = ""
 
         # TODO - Check that SchemaParser has been set
         if "DerivedData" in self.SchemaParser.SchemaConfig:
@@ -184,7 +184,8 @@ class Config(object):
                     value = self._calculate_function_value(value, field_name, field_dict,
                                                            schema_config=schema_config_data,
                                                            file_name=source_file_name)
-                    self.SchemaParser.SchemaConfig["DerivedData"]["fields"][field]["value"] = value
+                    if value:
+                        self.SchemaParser.SchemaConfig["DerivedData"]["fields"][field]["value"] = value
                     if field in self.trace_index.keys():
                         self.logging.debug("[TRACE {}]: Calculated function value = {}".format(field, value))
 
@@ -375,9 +376,9 @@ class Config(object):
                 fields[field]["ontologyMapping"] = "http://www.anl.gov/cfm/transform.owl#" + OntologyMapping
                 if fieldtrace:
                     self.logging.debug("[TRACE {}]: Found simple ontology mapping: {}".format(
-                                                 field, 
+                                                 field,
                                                  fields[field]["ontologyMapping"]))
-                
+
             elif "OntologyMappingMultiple" in schemaConfiguration[field]:
                 OntologyMappings = schemaConfiguration[field].pop("OntologyMappingMultiple")
                 fields[field]["ontologyMappingType"] = "multiple"
@@ -386,7 +387,7 @@ class Config(object):
                     fields[field]["ontologyMappings"].append("http://www.anl.gov/cfm/transform.owl#" + mapping)
                     if fieldtrace:
                         self.logging.debug("[TRACE {}]: Adding multiple ontology mappings: {}".format(
-                                                 field, 
+                                                 field,
                                                  fields[field]["ontologyMappings"][-1]))
                         self.trace_index[field]["dst_IRIs"].append(fields[field]["ontologyMappings"][-1])
 
@@ -401,15 +402,15 @@ class Config(object):
                     fields[field]["enumValues"][kv[0]]["ontologyMapping"] = "http://www.anl.gov/cfm/transform.owl#" + kv[1]
                     if fieldtrace:
                         self.logging.debug("[TRACE {}]: Adding enumerated ontology mappings: {}".format(
-                                                 field, 
+                                                 field,
                                                  fields[field]["enumValues"][kv[0]]["ontologyMappings"]))
                         self.trace_index[field]["dst_IRIs"].append(fields[field]["enumValues"][kv[0]]["ontologyMappings"])
-                    
+
             else:
                 fields[field]["ontologyMappingType"] = "none"
                 if fieldtrace:
                     self.logging.debug("[TRACE {}]: Found no ontology mapping".format(field))
-            
+
             for Directive in schemaConfiguration[field] :
                 if fieldtrace:
                     self.logging.debug("[TRACE {}]: Setting special directive {}".format(field, Directive))

--- a/FlexTransform/Configuration/ConfigFunctions/GlobalFunctions.py
+++ b/FlexTransform/Configuration/ConfigFunctions/GlobalFunctions.py
@@ -1,6 +1,4 @@
 """
-Created on Jun 13, 2015
-
 @author: cstrasburg
 """
 
@@ -19,21 +17,21 @@ class GlobalFunctions(object):
     """
 
     '''
-    The _FunctionNames dictionary should contain each function name understood by this class. Each is 
+    The _FunctionNames dictionary should contain each function name understood by this class. Each is
     mapped to a list with required fields to be passed in the args dictionary, or None if no args are required.
-    
+
     Allowed fields for the Args dictionary:
-    
+
     fieldName       - Optional - The name of the field being processed
 
     fileName        - Optional - The name of the loaded file (full path)
-    
+
     functionArg     - Optional - The string between the '(' and ')' in the function definition
 
     fieldDict       - Optional - The dictionary of the field where this method is defined
 
     '''
-    
+
     __FunctionNames = {
                           'getFileCreationDate': ['fileName'],
                           'getFileUUID': ['fileName', 'functionArg'],
@@ -44,22 +42,22 @@ class GlobalFunctions(object):
         Constructor
         """
         self.logging = logging.getLogger('FlexTransform.Configuration.ConfigFunctions.GlobalFunctions')
-        
+
     @classmethod
     def register_functions(cls):
         for FunctionName, RequiredArgs in cls.__FunctionNames.items():
             ConfigFunctionManager.register_function(FunctionName, RequiredArgs, 'GlobalFunctions')
-        
+
     def Execute(self, function_name, args):
         value = None
-         
+
         if function_name not in self.__FunctionNames:
             raise Exception('FunctionNotDefined',
                             'Function %s is not defined in GlobalFunctions' % (function_name))
-        
+
         elif function_name == 'getFileCreationDate':
             if 'fileName' in args:
-                try: 
+                try:
                     rawctime = os.path.getctime(args['fileName'])
                     ''' Convert to given time format '''
                     if 'fieldDict' in args and 'dateTimeFormat' in args['fieldDict'] and \
@@ -71,7 +69,7 @@ class GlobalFunctions(object):
                     self.logging.warn("Could not get file ctime for {}: {}".format(args['fileName'], e))
 
         elif function_name == 'getFileUUID':
-            if 'fileName' in args:
+            if 'fileName' in args and args['fileName']:
                 fileName = args['fileName']
                 baseName = os.path.basename(fileName)
                 p = re.compile(args['functionArg'])

--- a/FlexTransform/SyntaxParser/Parser.py
+++ b/FlexTransform/SyntaxParser/Parser.py
@@ -41,7 +41,7 @@ class Parser(object):
                 for z in x["dst_IRIs"]:
                     self.traceindex[z] = x
             self.logging.debug("Initialized Parser with tracelist of {} elements.".format(len(tracelist)))
-        
+
     @classmethod
     def UpdateKnownParsers(cls, ParserName, ParserClass):
         cls.__KnownParsers[ParserName] = ParserClass;
@@ -67,21 +67,22 @@ class Parser(object):
     def Read(self,file,configurationfile):
         '''
         Base document read method, must be implemented in subclasses
-        TODO: need proper subclassing: All subclasses should call this Read method as well, as it contains 
+        TODO: need proper subclassing: All subclasses should call this Read method as well, as it contains
         code common to all parsers.
         '''
-        
+
         ''' Ensure the derived data is available to all parsers, e.g. to extract information from the file
-            name or metadata 
+            name or metadata
         '''
         self.ParsedData = {}
         if 'DerivedData' in configurationfile.SchemaConfig:
             self.ParsedData['DerivedData'] = {}
             for field in configurationfile.SchemaConfig['DerivedData']['fields']:
-                self.ParsedData['DerivedData'][field] = configurationfile.SchemaConfig['DerivedData']['fields'][field]['value']
-                if self.trace and field in self.traceindex:
-                    self.logging.debug("[TRACE {}]: Read: value {} copied to ParsedData['DerivedData'] from SchemaConfig".format(field, self.ParsedData['DerivedData'][field]))
-    
+                if 'value' in configurationfile.SchemaConfig['DerivedData']['fields'][field] and configurationfile.SchemaConfig['DerivedData']['fields'][field]['value']:
+                    self.ParsedData['DerivedData'][field] = configurationfile.SchemaConfig['DerivedData']['fields'][field]['value']
+                    if self.trace and field in self.traceindex:
+                        self.logging.debug("[TRACE {}]: Read: value {} copied to ParsedData['DerivedData'] from SchemaConfig".format(field, self.ParsedData['DerivedData'][field]))
+
     def Write(self, file, FinalizedData):
         '''
         Base document write method, must be implemented in subclasses

--- a/FlexTransform/test/ToKeyValue_test.py
+++ b/FlexTransform/test/ToKeyValue_test.py
@@ -1,10 +1,9 @@
 import io
 import os
-import tempfile
 import unittest
 
 from FlexTransform import FlexTransform
-from FlexTransform.test.SampleInputs import STIXTLP, STIXACS, CFM13ALERT, CFM13ALERTUUID
+from FlexTransform.test.SampleInputs import STIXTLP, STIXACS, CFM13ALERT
 
 
 class TestCFM13AlertToKeyValue(unittest.TestCase):
@@ -21,10 +20,7 @@ class TestCFM13AlertToKeyValue(unittest.TestCase):
             transform.add_parser('keyvalue', input_file)
         output1_object = io.StringIO()
 
-        with tempfile.NamedTemporaryFile(mode="w+", prefix=CFM13ALERTUUID) as input_file:
-            input_file.write(CFM13ALERT)
-            input_file.seek(0)
-            transform.transform(input_file, 'cfm13alert', 'keyvalue', target_file=output1_object)
+        transform.transform(io.StringIO(CFM13ALERT), 'cfm13alert', 'keyvalue', target_file=output1_object)
         cls.output1 = []
         output1_object.seek(0)
         for line in output1_object.read().splitlines():

--- a/FlexTransform/test/ToStixACS_test.py
+++ b/FlexTransform/test/ToStixACS_test.py
@@ -1,11 +1,11 @@
 import io
 import os
-import tempfile
 import unittest
+
 from lxml import etree
 
-from FlexTransform.test.SampleInputs import CFM13ALERT, STIXTLP, KEYVALUE, CFM13ALERTUUID
 from FlexTransform import FlexTransform
+from FlexTransform.test.SampleInputs import CFM13ALERT, STIXTLP, KEYVALUE
 
 
 class CFM13Alert1ToSTIXACS(unittest.TestCase):
@@ -34,10 +34,7 @@ class CFM13Alert1ToSTIXACS(unittest.TestCase):
             transform.add_parser('stix_acs', input_file)
         output1_object = io.StringIO()
 
-        with tempfile.NamedTemporaryFile(mode="w+", prefix=CFM13ALERTUUID) as input_file:
-            input_file.write(CFM13ALERT)
-            input_file.seek(0)
-            transform.transform(input_file, 'cfm13alert', 'stix_acs', target_file=output1_object)
+        transform.transform(io.StringIO(CFM13ALERT), 'cfm13alert', 'stix_acs', target_file=output1_object)
         cls.output1 = etree.XML(output1_object.getvalue())
 
     def test_package_intent_type(self):

--- a/FlexTransform/test/ToStixTLP_test.py
+++ b/FlexTransform/test/ToStixTLP_test.py
@@ -1,13 +1,11 @@
 import io
 import os
-import tempfile
 import unittest
 
 from lxml import etree
 
 from FlexTransform import FlexTransform
-from FlexTransform.test.SampleInputs import CFM13ALERT, CFM13ALERTUUID, STIXACS, KEYVALUE
-
+from FlexTransform.test.SampleInputs import CFM13ALERT, STIXACS, KEYVALUE
 
 
 class TestCFM13AlertToSTIXTLP(unittest.TestCase):
@@ -36,10 +34,7 @@ class TestCFM13AlertToSTIXTLP(unittest.TestCase):
             transform.add_parser('stix', input_file)
         output1_object = io.StringIO()
 
-        with tempfile.NamedTemporaryFile(mode="w+", prefix=CFM13ALERTUUID) as input_file:
-            input_file.write(CFM13ALERT)
-            input_file.seek(0)
-            transform.transform(input_file, 'cfm13alert', 'stix', target_file=output1_object)
+        transform.transform(io.StringIO(CFM13ALERT), 'cfm13alert', 'stix', target_file=output1_object)
 
         cls.output1 = etree.XML(output1_object.getvalue())
 


### PR DESCRIPTION
Function Calculation can now accept empty strings for file name (allowing for file-like
objects to be used) and return _None_ if such a case is applicable.  Parsing code for
*MappedData* will now ignore `DerivedData` elements that are either missing `value`
or where `value=None`